### PR TITLE
Add Basic Info on Viewing the Specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # Specification
 This project contains the specification for the Render Wagon compatible Rendering Engines and Content Creators
+
+## Viewing
+A rendered version of this specification is currently viewable at: [https://specifications.renderwagon.dev/](https://specifications.renderwagon.dev/)
+
+## Viewing Locally
+Make sure to install the required dependencies:
+```bash
+pip install mkdocs-material mkdocs-minify-plugin mkdocs-redirects
+```
+
+A local server can be started with:
+```bash
+mkdocs serve
+```


### PR DESCRIPTION
# This PR
This PR adds basic info to the repository's README.md file describing how to view both the published version of the specification and any local version of the specification.